### PR TITLE
Add a scala BigDecimal codec / encoder / decoder

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/codecs.scala
+++ b/zio-json/shared/src/main/scala/zio/json/codecs.scala
@@ -44,6 +44,9 @@ object JsonCodec {
   implicit val float: JsonCodec[Float]                     = JsonCodec(JsonEncoder.float, JsonDecoder.float)
   implicit val bigDecimal: JsonCodec[java.math.BigDecimal] = JsonCodec(JsonEncoder.bigDecimal, JsonDecoder.bigDecimal)
 
+  implicit val scalaBigDecimal: JsonCodec[BigDecimal] =
+    JsonCodec(JsonEncoder.scalaBigDecimal, JsonDecoder.scalaBigDecimal)
+
   implicit def option[A](implicit c: JsonCodec[A]): JsonCodec[Option[A]] =
     JsonCodec(JsonEncoder.option(c.encoder), JsonDecoder.option(c.decoder))
 

--- a/zio-json/shared/src/main/scala/zio/json/codecs.scala
+++ b/zio-json/shared/src/main/scala/zio/json/codecs.scala
@@ -65,8 +65,8 @@ object JsonCodec {
 
           override def decoder: JsonDecoder[A] = decoder0
 
-//          override def unsafeDecodeMissing(trace: List[JsonError]): A =
-//            decoder0.unsafeDecodeMissing(trace)
+          override def unsafeDecodeMissing(trace: List[JsonError]): A =
+            decoder0.unsafeDecodeMissing(trace)
 
           override def unsafeDecode(trace: List[JsonError], in: RetractReader): A =
             decoder0.unsafeDecode(trace, in)

--- a/zio-json/shared/src/main/scala/zio/json/codecs.scala
+++ b/zio-json/shared/src/main/scala/zio/json/codecs.scala
@@ -27,8 +27,28 @@ trait JsonCodec[A] extends JsonDecoder[A] with JsonEncoder[A] {
   override def xmap[B](f: A => B, g: B => A): JsonCodec[B] =
     JsonCodec(encoder.contramap(g), decoder.map(f))
 }
+
 object JsonCodec {
   def apply[A](implicit jsonCodec: JsonCodec[A]): JsonCodec[A] = jsonCodec
+
+  implicit val string: JsonCodec[String]                   = JsonCodec(JsonEncoder.string, JsonDecoder.string)
+  implicit val boolean: JsonCodec[Boolean]                 = JsonCodec(JsonEncoder.boolean, JsonDecoder.boolean)
+  implicit val char: JsonCodec[Char]                       = JsonCodec(JsonEncoder.char, JsonDecoder.char)
+  implicit val long: JsonCodec[Long]                       = JsonCodec(JsonEncoder.long, JsonDecoder.long)
+  implicit val symbol: JsonCodec[Symbol]                   = JsonCodec(JsonEncoder.symbol, JsonDecoder.symbol)
+  implicit val byte: JsonCodec[Byte]                       = JsonCodec(JsonEncoder.byte, JsonDecoder.byte)
+  implicit val short: JsonCodec[Short]                     = JsonCodec(JsonEncoder.short, JsonDecoder.short)
+  implicit val int: JsonCodec[Int]                         = JsonCodec(JsonEncoder.int, JsonDecoder.int)
+  implicit val bigInteger: JsonCodec[java.math.BigInteger] = JsonCodec(JsonEncoder.bigInteger, JsonDecoder.bigInteger)
+  implicit val double: JsonCodec[Double]                   = JsonCodec(JsonEncoder.double, JsonDecoder.double)
+  implicit val float: JsonCodec[Float]                     = JsonCodec(JsonEncoder.float, JsonDecoder.float)
+  implicit val bigDecimal: JsonCodec[java.math.BigDecimal] = JsonCodec(JsonEncoder.bigDecimal, JsonDecoder.bigDecimal)
+
+  implicit def option[A](implicit c: JsonCodec[A]): JsonCodec[Option[A]] =
+    JsonCodec(JsonEncoder.option(c.encoder), JsonDecoder.option(c.decoder))
+
+  implicit def either[A, B](implicit ac: JsonCodec[A], bc: JsonCodec[B]): JsonCodec[Either[A, B]] =
+    JsonCodec(JsonEncoder.either(ac.encoder, bc.encoder), JsonDecoder.either(ac.decoder, bc.decoder))
 
   /**
    * Derives a `JsonCodec[A]` from an encoder and a decoder.
@@ -41,14 +61,17 @@ object JsonCodec {
         e
       case other =>
         new JsonCodec[A] {
-          def encoder: JsonEncoder[A] = encoder0
+          override def encoder: JsonEncoder[A] = encoder0
 
-          def decoder: JsonDecoder[A] = decoder0
+          override def decoder: JsonDecoder[A] = decoder0
 
-          def unsafeDecode(trace: List[JsonError], in: RetractReader): A =
+//          override def unsafeDecodeMissing(trace: List[JsonError]): A =
+//            decoder0.unsafeDecodeMissing(trace)
+
+          override def unsafeDecode(trace: List[JsonError], in: RetractReader): A =
             decoder0.unsafeDecode(trace, in)
 
-          def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit =
+          override def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit =
             encoder0.unsafeEncode(a, indent, out)
         }
     }

--- a/zio-json/shared/src/main/scala/zio/json/encoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/encoder.scala
@@ -6,7 +6,7 @@ import java.time.temporal.ChronoField.YEAR
 import scala.annotation._
 import scala.collection.immutable
 
-import zio.{ Chunk }
+import zio.Chunk
 import zio.json.internal.{ FastStringWrite, Write }
 
 trait JsonEncoder[A] extends JsonEncoderPlatformSpecific[A] { self =>
@@ -29,6 +29,7 @@ trait JsonEncoder[A] extends JsonEncoderPlatformSpecific[A] { self =>
    * by the specified user-defined function.
    */
   final def contramap[B](f: B => A): JsonEncoder[B] = new JsonEncoder[B] {
+
     override def unsafeEncode(b: B, indent: Option[Int], out: Write): Unit =
       self.unsafeEncode(f(b), indent, out)
     override def isNothing(b: B): Boolean = self.isNothing(f(b))
@@ -79,6 +80,7 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority0 {
   def apply[A](implicit a: JsonEncoder[A]): JsonEncoder[A] = a
 
   implicit val string: JsonEncoder[String] = new JsonEncoder[String] {
+
     override def unsafeEncode(a: String, indent: Option[Int], out: Write): Unit = {
       out.write('"')
       var i   = 0
@@ -111,23 +113,25 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority0 {
     def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = out.write(s""""${f(a)}"""")
   }
 
-  implicit val boolean: JsonEncoder[Boolean] = explicit(_.toString)
-  implicit val char: JsonEncoder[Char]       = string.contramap(_.toString)
-  implicit val symbol: JsonEncoder[Symbol]   = string.contramap(_.name)
-
+  implicit val boolean: JsonEncoder[Boolean]                 = explicit(_.toString)
+  implicit val char: JsonEncoder[Char]                       = string.contramap(_.toString)
+  implicit val symbol: JsonEncoder[Symbol]                   = string.contramap(_.name)
   implicit val byte: JsonEncoder[Byte]                       = explicit(_.toString)
   implicit val short: JsonEncoder[Short]                     = explicit(_.toString)
   implicit val int: JsonEncoder[Int]                         = explicit(_.toString)
   implicit val long: JsonEncoder[Long]                       = explicit(_.toString)
   implicit val bigInteger: JsonEncoder[java.math.BigInteger] = explicit(_.toString)
+
   implicit val double: JsonEncoder[Double] = explicit { n =>
     if (n.isNaN || n.isInfinite) s""""$n""""
     else n.toString
   }
   implicit val float: JsonEncoder[Float]                     = double.contramap(_.toDouble)
   implicit val bigDecimal: JsonEncoder[java.math.BigDecimal] = explicit(_.toString)
+  implicit val scalaBigDecimal: JsonEncoder[BigDecimal]      = explicit(_.toString)
 
   implicit def option[A](implicit A: JsonEncoder[A]): JsonEncoder[Option[A]] = new JsonEncoder[Option[A]] {
+
     def unsafeEncode(oa: Option[A], indent: Option[Int], out: Write): Unit = oa match {
       case None    => out.write("null")
       case Some(a) => A.unsafeEncode(a, indent, out)
@@ -139,11 +143,13 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority0 {
     case None    => None
     case Some(i) => Some(i + 1)
   }
+
   def pad(indent: Option[Int], out: Write): Unit =
     indent.foreach(i => out.write("\n" + (" " * 2 * i)))
 
   implicit def either[A, B](implicit A: JsonEncoder[A], B: JsonEncoder[B]): JsonEncoder[Either[A, B]] =
     new JsonEncoder[Either[A, B]] {
+
       def unsafeEncode(eab: Either[A, B], indent: Option[Int], out: Write): Unit = {
         out.write('{')
         val indent_ = bump(indent)
@@ -193,8 +199,10 @@ private[json] trait EncoderLowPriority1 extends EncoderLowPriority2 { this: Json
 }
 
 private[json] trait EncoderLowPriority2 extends EncoderLowPriority3 { this: JsonEncoder.type =>
+
   implicit def iterable[A, T[X] <: Iterable[X]](implicit A: JsonEncoder[A]): JsonEncoder[T[A]] =
     new JsonEncoder[T[A]] {
+
       def unsafeEncode(as: T[A], indent: Option[Int], out: Write): Unit = {
         out.write('[')
         var first = true
@@ -213,6 +221,7 @@ private[json] trait EncoderLowPriority2 extends EncoderLowPriority3 { this: Json
     K: JsonFieldEncoder[K],
     A: JsonEncoder[A]
   ): JsonEncoder[T[K, A]] = new JsonEncoder[T[K, A]] {
+
     def unsafeEncode(kvs: T[K, A], indent: Option[Int], out: Write): Unit = {
       if (kvs.isEmpty) return out.write("{}")
 
@@ -256,28 +265,35 @@ private[json] trait EncoderLowPriority3 { this: JsonEncoder.type =>
   implicit val dayOfWeek: JsonEncoder[DayOfWeek] = stringify(_.toString)
   implicit val duration: JsonEncoder[Duration]   = stringify(_.toString)
   implicit val instant: JsonEncoder[Instant]     = stringify(_.toString)
+
   implicit val localDate: JsonEncoder[LocalDate] = stringify(
     _.format(DateTimeFormatter.ISO_LOCAL_DATE)
   )
+
   implicit val localDateTime: JsonEncoder[LocalDateTime] = stringify(
     _.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
   )
+
   implicit val localTime: JsonEncoder[LocalTime] = stringify(
     _.format(DateTimeFormatter.ISO_LOCAL_TIME)
   )
   implicit val month: JsonEncoder[Month]       = stringify(_.toString)
   implicit val monthDay: JsonEncoder[MonthDay] = stringify(_.toString)
+
   implicit val offsetDateTime: JsonEncoder[OffsetDateTime] = stringify(
     _.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
   )
+
   implicit val offsetTime: JsonEncoder[OffsetTime] = stringify(
     _.format(DateTimeFormatter.ISO_OFFSET_TIME)
   )
   implicit val period: JsonEncoder[Period] = stringify(_.toString)
+
   private val yearFormatter =
     new DateTimeFormatterBuilder().appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD).toFormatter
   implicit val year: JsonEncoder[Year]           = stringify(_.format(yearFormatter))
   implicit val yearMonth: JsonEncoder[YearMonth] = stringify(_.toString)
+
   implicit val zonedDateTime: JsonEncoder[ZonedDateTime] = stringify(
     _.format(DateTimeFormatter.ISO_ZONED_DATE_TIME)
   )
@@ -294,7 +310,9 @@ trait JsonFieldEncoder[-A] { self =>
 
   def unsafeEncodeField(in: A): String
 }
+
 object JsonFieldEncoder {
+
   implicit val string: JsonFieldEncoder[String] = new JsonFieldEncoder[String] {
     def unsafeEncodeField(in: String): String = in
   }

--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -45,6 +45,7 @@ object Lexer {
         in.retract()
         true
     }
+
   def nextArrayElement(trace: List[JsonError], in: OneCharReader): Boolean =
     (in.nextNonWhitespace(): @switch) match {
       case ',' => true
@@ -90,6 +91,7 @@ object Lexer {
   private[this] val ull: Array[Char]  = "ull".toCharArray
   private[this] val alse: Array[Char] = "alse".toCharArray
   private[this] val rue: Array[Char]  = "rue".toCharArray
+
   def skipValue(trace: List[JsonError], in: RetractReader): Unit =
     (in.nextNonWhitespace(): @switch) match {
       case 'n' => readChars(trace, in, ull, "null")
@@ -391,6 +393,7 @@ final class StringMatrix(val xs: Array[String]) {
   val height: Int         = xs.map(_.length).max
   val lengths: Array[Int] = xs.map(_.length)
   val initial: Long       = (0 until width).foldLeft(0L)((bs, r) => bs | (1L << r))
+
   private val matrix: Array[Int] = {
     val m           = Array.fill[Int](width * height)(-1)
     var string: Int = 0

--- a/zio-json/shared/src/test/scala/zio/json/CodecSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/CodecSpec.scala
@@ -1,0 +1,170 @@
+package testzio.json
+
+import scala.collection.immutable
+
+import zio.json._
+import zio.test.Assertion._
+import zio.test.environment.Live
+import zio.test.{ DefaultRunnableSpec, assert, _ }
+import zio.{ test => _, _ }
+
+object CodecSpec extends DefaultRunnableSpec {
+
+  def spec: Spec[ZEnv with Live, TestFailure[Any], TestSuccess] =
+    suite("Codec")(
+      suite("Decoding")(
+        test("empty") {
+          import exampleempty._
+          // this big integer consumes more than 128 bits
+          assert("{}".fromJson[Empty])(
+            isRight(equalTo(Empty(None)))
+          )
+        },
+        test("primitives") {
+          // this big integer consumes more than 128 bits
+          assert("170141183460469231731687303715884105728".fromJson[java.math.BigInteger])(
+            isLeft(equalTo("(expected a 128 bit BigInteger)"))
+          )
+        },
+        test("eithers") {
+          val bernies = List("""{"a":1}""", """{"left":1}""", """{"Left":1}""")
+          val trumps  = List("""{"b":2}""", """{"right":2}""", """{"Right":2}""")
+
+          assert(bernies.map(_.fromJson[Either[Int, Int]]))(
+            forall(isRight(isLeft(equalTo(1))))
+          ) && assert(trumps.map(_.fromJson[Either[Int, Int]]))(
+            forall(isRight(isRight(equalTo(2))))
+          )
+        },
+        test("parameterless products") {
+          import exampleproducts._
+
+          // actually anything works... consider this a canary test because if only
+          // the empty object is supported that's fine.
+          assert("""{}""".fromJson[Parameterless])(isRight(equalTo(Parameterless()))) &&
+          assert("""null""".fromJson[Parameterless])(isRight(equalTo(Parameterless()))) &&
+          assert("""{"field":"value"}""".fromJson[Parameterless])(isRight(equalTo(Parameterless())))
+        },
+        test("no extra fields") {
+          import exampleproducts._
+
+          assert("""{"s":""}""".fromJson[OnlyString])(isRight(equalTo(OnlyString("")))) &&
+          assert("""{"s":"","t":""}""".fromJson[OnlyString])(isLeft(equalTo("(invalid extra field)")))
+        },
+        test("sum encoding") {
+          import examplesum._
+
+          assert("""{"Child1":{}}""".fromJson[Parent])(isRight(equalTo(Child1()))) &&
+          assert("""{"Child2":{}}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
+          assert("""{"type":"Child1"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)")))
+        },
+        test("sum alternative encoding") {
+          import examplealtsum._
+
+          assert("""{"hint":"Cain"}""".fromJson[Parent])(isRight(equalTo(Child1()))) &&
+          assert("""{"hint":"Abel"}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
+          assert("""{"hint":"Samson"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)"))) &&
+          assert("""{"Cain":{}}""".fromJson[Parent])(isLeft(equalTo("(missing hint 'hint')")))
+        },
+        test("unicode") {
+          assert(""""€🐵🥰"""".fromJson[String])(isRight(equalTo("€🐵🥰")))
+        },
+        test("Seq") {
+          val jsonStr  = """["5XL","2XL","XL"]"""
+          val expected = Seq("5XL", "2XL", "XL")
+
+          assert(jsonStr.fromJson[Seq[String]])(isRight(equalTo(expected)))
+        },
+        test("Vector") {
+          val jsonStr  = """["5XL","2XL","XL"]"""
+          val expected = Vector("5XL", "2XL", "XL")
+
+          assert(jsonStr.fromJson[Vector[String]])(isRight(equalTo(expected)))
+        },
+        test("SortedSet") {
+          val jsonStr  = """["5XL","2XL","XL"]"""
+          val expected = immutable.SortedSet("5XL", "2XL", "XL")
+
+          assert(jsonStr.fromJson[immutable.SortedSet[String]])(isRight(equalTo(expected)))
+        },
+        test("HashSet") {
+          val jsonStr  = """["5XL","2XL","XL"]"""
+          val expected = immutable.HashSet("5XL", "2XL", "XL")
+
+          assert(jsonStr.fromJson[immutable.HashSet[String]])(isRight(equalTo(expected)))
+        },
+        test("Set") {
+          val jsonStr  = """["5XL","2XL","XL"]"""
+          val expected = Set("5XL", "2XL", "XL")
+
+          assert(jsonStr.fromJson[Set[String]])(isRight(equalTo(expected)))
+        },
+        test("Map") {
+          val jsonStr  = """{"5XL":3,"2XL":14,"XL":159}"""
+          val expected = Map("5XL" -> 3, "2XL" -> 14, "XL" -> 159)
+
+          assert(jsonStr.fromJson[Map[String, Int]])(isRight(equalTo(expected)))
+        },
+        test("zio.Chunk") {
+          val jsonStr  = """["5XL","2XL","XL"]"""
+          val expected = Chunk("5XL", "2XL", "XL")
+
+          assert(jsonStr.fromJson[Chunk[String]])(isRight(equalTo(expected)))
+        }
+      )
+    )
+
+  object exampleproducts {
+    case class Parameterless()
+
+    object Parameterless {
+      implicit val codec: JsonCodec[Parameterless] = DeriveJsonCodec.gen[Parameterless]
+    }
+
+    @jsonNoExtraFields
+    case class OnlyString(s: String)
+
+    object OnlyString {
+      implicit val codec: JsonCodec[OnlyString] = DeriveJsonCodec.gen[OnlyString]
+    }
+  }
+
+  object examplesum {
+    sealed abstract class Parent
+
+    object Parent {
+      implicit val codec: JsonCodec[Parent] = DeriveJsonCodec.gen[Parent]
+    }
+    case class Child1() extends Parent
+    case class Child2() extends Parent
+  }
+
+  object exampleempty {
+    case class Empty(a: Option[String])
+
+    object Empty {
+      implicit val codec: JsonCodec[Empty] = DeriveJsonCodec.gen[Empty]
+    }
+  }
+
+  object examplealtsum {
+
+    @jsonDiscriminator("hint")
+    sealed abstract class Parent
+
+    object Parent {
+      implicit val codec: JsonCodec[Parent] = DeriveJsonCodec.gen[Parent]
+    }
+
+    @jsonHint("Cain")
+    case class Child1() extends Parent
+
+    @jsonHint("Abel")
+    case class Child2() extends Parent
+  }
+
+  object logEvent {
+    case class Event(at: Long, message: String)
+    implicit val codec: JsonCodec[Event] = DeriveJsonCodec.gen[Event]
+  }
+}

--- a/zio-json/shared/src/test/scala/zio/json/CodecSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/CodecSpec.scala
@@ -15,7 +15,6 @@ object CodecSpec extends DefaultRunnableSpec {
       suite("Decoding")(
         test("empty") {
           import exampleempty._
-          // this big integer consumes more than 128 bits
           assert("{}".fromJson[Empty])(
             isRight(equalTo(Empty(None)))
           )

--- a/zio-json/shared/src/test/scala/zio/json/CodecSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/CodecSpec.scala
@@ -20,10 +20,11 @@ object CodecSpec extends DefaultRunnableSpec {
           )
         },
         test("primitives") {
+          val exampleBDString = "234234.234"
           // this big integer consumes more than 128 bits
           assert("170141183460469231731687303715884105728".fromJson[java.math.BigInteger])(
             isLeft(equalTo("(expected a 128 bit BigInteger)"))
-          )
+          ) && assert(exampleBDString.fromJson[BigDecimal])(isRight(equalTo(BigDecimal(exampleBDString))))
         },
         test("eithers") {
           val bernies = List("""{"a":1}""", """{"left":1}""", """{"Left":1}""")

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -9,9 +9,13 @@ import zio.test.{ DefaultRunnableSpec, _ }
 import zio.{ test => _, _ }
 
 object DecoderSpec extends DefaultRunnableSpec {
+
   def spec: Spec[ZEnv with Live, TestFailure[Any], TestSuccess] =
     suite("Decoder")(
-      test("primitives") {
+      test("BigDecimal") {
+        assert("123".fromJson[BigDecimal])(isRight(equalTo(BigDecimal(123))))
+      },
+      test("BigInteger too large") {
         // this big integer consumes more than 128 bits
         assert("170141183460469231731687303715884105728".fromJson[java.math.BigInteger])(
           isLeft(equalTo("(expected a 128 bit BigInteger)"))
@@ -106,14 +110,18 @@ object DecoderSpec extends DefaultRunnableSpec {
 
   object exampleproducts {
     case class Parameterless()
+
     object Parameterless {
+
       implicit val decoder: JsonDecoder[Parameterless] =
         DeriveJsonDecoder.gen[Parameterless]
     }
 
     @jsonNoExtraFields
     case class OnlyString(s: String)
+
     object OnlyString {
+
       implicit val decoder: JsonDecoder[OnlyString] =
         DeriveJsonDecoder.gen[OnlyString]
     }
@@ -121,6 +129,7 @@ object DecoderSpec extends DefaultRunnableSpec {
 
   object examplesum {
     sealed abstract class Parent
+
     object Parent {
       implicit val decoder: JsonDecoder[Parent] = DeriveJsonDecoder.gen[Parent]
     }
@@ -129,8 +138,10 @@ object DecoderSpec extends DefaultRunnableSpec {
   }
 
   object examplealtsum {
+
     @jsonDiscriminator("hint")
     sealed abstract class Parent
+
     object Parent {
       implicit val decoder: JsonDecoder[Parent] = DeriveJsonDecoder.gen[Parent]
     }

--- a/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
@@ -7,6 +7,7 @@ import zio.test.{ DefaultRunnableSpec, assert, _ }
 
 // zioJsonJVM/testOnly testzio.json.EncoderSpec
 object EncoderSpec extends DefaultRunnableSpec {
+
   def spec: Spec[Annotations, TestFailure[Any], TestSuccess] =
     suite("Encoder")(
       suite("primitives")(
@@ -119,24 +120,32 @@ object EncoderSpec extends DefaultRunnableSpec {
 
   object exampleproducts {
     case class Parameterless()
+
     object Parameterless {
+
       implicit val encoder: JsonEncoder[Parameterless] =
         DeriveJsonEncoder.gen[Parameterless]
     }
 
     case class OnlyString(s: String)
+
     object OnlyString {
+
       implicit val encoder: JsonEncoder[OnlyString] =
         DeriveJsonEncoder.gen[OnlyString]
     }
 
     case class CoupleOfThings(@jsonField("j") i: Int, f: Option[Float], b: Boolean)
+
     object CoupleOfThings {
+
       implicit val encoder: JsonEncoder[CoupleOfThings] =
         DeriveJsonEncoder.gen[CoupleOfThings]
     }
     case class OptionalAndRequired(i: Option[Int], s: String)
+
     object OptionalAndRequired {
+
       implicit val encoder: JsonEncoder[OptionalAndRequired] =
         DeriveJsonEncoder.gen[OptionalAndRequired]
     }
@@ -145,22 +154,27 @@ object EncoderSpec extends DefaultRunnableSpec {
   object examplesum {
 
     sealed abstract class Parent
+
     object Parent {
       implicit val encoder: JsonEncoder[Parent] = DeriveJsonEncoder.gen[Parent]
     }
     case class Child1() extends Parent
+
     @jsonHint("Cain")
     case class Child2() extends Parent
   }
 
   object examplealtsum {
+
     @jsonDiscriminator("hint")
     sealed abstract class Parent
+
     object Parent {
       implicit val encoder: JsonEncoder[Parent] = DeriveJsonEncoder.gen[Parent]
     }
 
     case class Child1() extends Parent
+
     @jsonHint("Abel")
     case class Child2(s: Option[String]) extends Parent
   }

--- a/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
@@ -3,7 +3,7 @@ package testzio.json
 import zio.json._
 import zio.test.Assertion._
 import zio.test.TestAspect._
-import zio.test.{ DefaultRunnableSpec, assert, _ }
+import zio.test._
 
 // zioJsonJVM/testOnly testzio.json.EncoderSpec
 object EncoderSpec extends DefaultRunnableSpec {
@@ -26,16 +26,17 @@ object EncoderSpec extends DefaultRunnableSpec {
           assert(Symbol("c").toJson)(equalTo("\"c\""))
         },
         test("numerics") {
+          val exampleBigIntStr     = "170141183460469231731687303715884105728"
+          val exampleBigDecimalStr = "170141183460469231731687303715884105728.4433"
           assert((1: Byte).toJson)(equalTo("1")) &&
           assert((1: Short).toJson)(equalTo("1")) &&
           assert((1: Int).toJson)(equalTo("1")) &&
-          assert((1L).toJson)(equalTo("1")) &&
-          assert((new java.math.BigInteger("1")).toJson)(equalTo("1")) &&
-          assert((new java.math.BigInteger("170141183460469231731687303715884105728")).toJson)(
-            equalTo("170141183460469231731687303715884105728")
-          ) &&
-          assert((1.0f).toJson)(equalTo("1.0")) &&
-          assert((1.0d).toJson)(equalTo("1.0"))
+          assert(1L.toJson)(equalTo("1")) &&
+          assert(new java.math.BigInteger("1").toJson)(equalTo("1")) &&
+          assert(new java.math.BigInteger(exampleBigIntStr).toJson)(equalTo(exampleBigIntStr)) &&
+          assert(BigDecimal(exampleBigDecimalStr).toJson)(equalTo(exampleBigDecimalStr)) &&
+          assert(1.0f.toJson)(equalTo("1.0")) &&
+          assert(1.0d.toJson)(equalTo("1.0"))
         } @@ jvmOnly,
         test("NaN / Infinity") {
           assert(Float.NaN.toJson)(equalTo("\"NaN\"")) &&


### PR DESCRIPTION
Hi @fommil! As of right now, there is only a `java.math.BigDecimal` encoder and decoder. This PR adds the encoder and decoder for Scala's `BigDecimal`. Since this touches many of the same files from my PR earlier today, I'll rebase on `zio/zio-json` when the first one is merged, but this one gives a clean diff for now.